### PR TITLE
Port removed from master

### DIFF
--- a/src/bin/master.rs
+++ b/src/bin/master.rs
@@ -25,13 +25,11 @@ type Db = Arc<Mutex<HashMap<String, Bytes>>>;
 
 #[tokio::main]
 async fn main() {
-    let args = Cli::parse();
-
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::DEBUG)
         .init();
 
-    let addr = format!("127.0.0.1:{0}", args.port);
+    let addr = format!("127.0.0.1:6969");
     event!(Level::INFO, "Starting master service on address: {addr}");
     let listener = match TcpListener::bind(addr).await {
         Ok(listener) => {


### PR DESCRIPTION
Since master starts always at port 6969, we don't need to input it by hand each time we start the master.