### PR TITLE
Cache is now mutexed

### DIFF
--- a/src/bin/partition.rs
+++ b/src/bin/partition.rs
@@ -66,7 +66,7 @@ pub async fn main() {
                 continue;
             }
         };
-        let cache_clone = cache.clone();
+        let cache_clone = Arc::clone(&cache);
         tokio::spawn(async move {
             stream.readable().await.unwrap();
             handle_connection(stream, cache_clone).await;


### PR DESCRIPTION
Now cache is mutexed using `Arc::clone`. 

======= THIS DOES NOT WORK UNLESS THIS [PR](https://github.com/stano45/hit-or-miss/pull/18) IS MERGED =======