### PR TITLE
LSD parsing added

### DIFF
--- a/src/bin/master.rs
+++ b/src/bin/master.rs
@@ -94,7 +94,7 @@ async fn handle_connection(mut socket: TcpStream, ring: Ring) -> Result<(), Erro
             Ok(parsed_request) => {
                 event!(Level::DEBUG, "Parsed request: {:?}", parsed_request);
                 match parsed_request.cmd {
-                    CommandType::Get | CommandType::Set | CommandType::Delete => {
+                    CommandType::Get | CommandType::Set | CommandType::Delete | CommandType::Lsd => {
                         forward_to_partition(socket, parsed_request, ring).await;
                         Ok(())
                     }
@@ -105,9 +105,6 @@ async fn handle_connection(mut socket: TcpStream, ring: Ring) -> Result<(), Erro
                     CommandType::ListPartitions => {
                         handle_list(socket, ring).await;
                         Ok(())
-                    }
-                    CommandType::LSD => {
-                        unimplemented!("Send LSD to all partition and aggregate response");
                     }
                     _ => {
                         socket

--- a/src/bin/master.rs
+++ b/src/bin/master.rs
@@ -94,7 +94,10 @@ async fn handle_connection(mut socket: TcpStream, ring: Ring) -> Result<(), Erro
             Ok(parsed_request) => {
                 event!(Level::DEBUG, "Parsed request: {:?}", parsed_request);
                 match parsed_request.cmd {
-                    CommandType::Get | CommandType::Set | CommandType::Delete | CommandType::Lsd => {
+                    CommandType::Get
+                    | CommandType::Set
+                    | CommandType::Delete
+                    | CommandType::Lsd => {
                         forward_to_partition(socket, parsed_request, ring).await;
                         Ok(())
                     }

--- a/src/bin/partition.rs
+++ b/src/bin/partition.rs
@@ -1,8 +1,8 @@
 use core::panic;
 use hitormiss::error::{Error, ErrorCode};
 use hitormiss::parser::{
-    build_error_response, build_hit_response, build_miss_response, build_notify_request,
-    build_ok_response, parse_request, CommandType, build_lsd_response,
+    build_error_response, build_hit_response, build_lsd_response, build_miss_response,
+    build_notify_request, build_ok_response, parse_request, CommandType,
 };
 use lru::LruCache;
 use std::num::NonZeroUsize;

--- a/src/bin/partition.rs
+++ b/src/bin/partition.rs
@@ -2,7 +2,7 @@ use core::panic;
 use hitormiss::error::{Error, ErrorCode};
 use hitormiss::parser::{
     build_error_response, build_hit_response, build_miss_response, build_notify_request,
-    build_ok_response, parse_request, CommandType,
+    build_ok_response, parse_request, CommandType, build_lsd_response,
 };
 use lru::LruCache;
 use std::num::NonZeroUsize;
@@ -65,6 +65,9 @@ pub async fn main() {
                                 .await
                                 .unwrap();
                         }
+                    }
+                    CommandType::Lsd => {
+                        stream.write_all(&build_lsd_response(&cache)).await.unwrap();
                     }
                     CommandType::Set => {
                         if let (Some(key), Some(value)) = (parsed_request.key, parsed_request.value)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use crate::error::Error;
 use crate::error::ErrorCode;
-use std::str;
 use lru::LruCache;
+use std::str;
 
 // Add CommandType enum
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -41,7 +41,9 @@ pub fn parse_request(mut message: Vec<u8>) -> Result<ParsedRequest, Error> {
     let cmd = extract_cmd(&parts)?;
 
     let key = match cmd {
-        CommandType::Get | CommandType::Set | CommandType::Delete | CommandType::Lsd => extract_key(&parts),
+        CommandType::Get | CommandType::Set | CommandType::Delete | CommandType::Lsd => {
+            extract_key(&parts)
+        }
         _ => Ok(None),
     }?;
 
@@ -118,11 +120,11 @@ pub fn build_hit_response(key: &str, value: &str) -> Vec<u8> {
 
 pub fn build_lsd_response(cache: &LruCache<String, String>) -> Vec<u8> {
     let mut s: String = "".to_owned();
-    for(key, val) in cache.iter() {
+    for (key, val) in cache.iter() {
         s.push_str(&format!("Key: {}, Value: {} \n", key, val).to_owned());
     }
     s.into_bytes()
-} 
+}
 
 pub fn build_miss_response(key: &str) -> Vec<u8> {
     format!("MSS {}\0", key).into_bytes()


### PR DESCRIPTION
Now the user can send `LSD <key>` as a command and it will get parsed and forwarded to a partition. Then the partition will send back all the data that it has in a string. The output looks like in the screenshot below.
![Screenshot from 2023-04-03 12-58-17](https://user-images.githubusercontent.com/17514555/229491599-2d55dce4-393e-4579-9473-52a64004e025.png)
